### PR TITLE
Add Python trainer with resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ python train.py [--validation_interval N]
 ```
 The script iterates over jobsets from `data/jobsets/{sampled,real,synthetic}`. For each episode it calls `src/cqsim.py` and saves weights to `weights/theta/dras_theta_policy_<episode>.weights.h5`.
 
-If weight files already exist the script resumes from the latest episode. Every `N` episodes (default 5) it runs the model on `data/jobsets/validation_2023_jan.swf` and prints the average reward from the generated `.rew` files so you can track convergence.
+If weight files already exist the script resumes from the latest episode. Every `N` episodes (default 5) it runs the model on `data/jobsets/validation_2023_jan.swf` and prints the average reward from the generated `.rew` files so you can track convergence. During training batches the simulator also prints the batch loss so you can monitor learning progress.
 
 ## Validation
 To evaluate a range of weights later you can use the legacy bash script from inside `src`:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# RL HPC Scheduler
+
+This project contains tools to train and evaluate a reinforcement-learning based job scheduler using traces from the Theta supercomputer. Jobsets are provided in the `data/jobsets` directory in Standard Workload Format (SWF).
+
+## Requirements
+- Python 3.8+
+- TensorFlow 2
+- numpy, pandas and other common scientific packages
+
+Install dependencies with pip:
+```bash
+pip install tensorflow pandas numpy
+```
+
+## Training
+Run the training script from the project root:
+```bash
+python train.py [--validation_interval N]
+```
+The script iterates over jobsets from `data/jobsets/{sampled,real,synthetic}`. For each episode it calls `src/cqsim.py` and saves weights to `weights/theta/dras_theta_policy_<episode>.weights.h5`.
+
+If weight files already exist the script resumes from the latest episode. Every `N` episodes (default 5) it runs the model on `data/jobsets/validation_2023_jan.swf` and prints the average reward from the generated `.rew` files so you can track convergence.
+
+## Validation
+To evaluate a range of weights later you can use the legacy bash script from inside `src`:
+```bash
+cd src
+bash validate.bash
+```
+Results are written to `data/results/theta` and debug logs to `data/debug/theta`.
+
+## Configuration
+Scheduler parameters are defined in `src/Config/config_sys.set`. Notable options:
+- `reward_type` – selects the reward calculation:
+  - `1` utilisation only
+  - `2` wait-time only
+  - `3` utilisation + wait-time
+  - `4` utilisation with priority award
+  - `5` node occupancy, wait time and job size (default)
+  - `6` job size only
+  - `7` carbon-aware reward
+- `weight_name` – base name for the weight files
+- `weight_num` – starting episode when running in evaluation mode
+- `is_training` – `1` for training, `0` for inference
+
+## Data
+Training and validation jobsets are SWF files containing one job per line after a small header. They can be generated from raw CSV traces using the tools in `src/DataPreparation/jobset_generator.py`. Each line includes submit time, run time, resource requests and a final carbon consideration index used by the carbon-aware reward.
+
+Place generated jobsets in the respective subfolders of `data/jobsets` before running `train.py`.
+

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,0 @@
-python create_jobsets.py \             
-    --train_csv data/raw/theta_trace_2022.csv \
-    --valtest_csv data/raw/theta_trace_2023.csv \
-    --output_dir data/jobsets# rl-hpc-scheduler
-# rl-hpc-scheduler
-# rl-hpc-scheduler
-# rl-hpc-scheduler

--- a/src/CqSim/Cqsim_sim.py
+++ b/src/CqSim/Cqsim_sim.py
@@ -788,10 +788,7 @@ class Cqsim_sim:
 
                 time1 = time.time()
 
-                print('Time 1: get_batch_rewards_span', time1-start_train_time)
-
-
-                print('_____batch training_____')
+                print('----- batch training -----')
 
                 #print('self.state_seq',self.state_seq)
                 #print('self.action_seq',self.action_seq)
@@ -808,6 +805,8 @@ class Cqsim_sim:
                 else:
                     cost = self.module['learning'].learn(
                         self.state_seq, self.action_seq, self.reward_seq)
+
+                print(f'batch loss: {float(cost):.4f}')
 
 
                 #batch_delta = []

--- a/src/CqSim/Cqsim_sim.py
+++ b/src/CqSim/Cqsim_sim.py
@@ -168,25 +168,28 @@ class Cqsim_sim:
                 else:
                     print("................... No existing weight files found, starting from episode 0")
 
-                policy_filename = self.weight_fn+"_policy_"+str(lastest_num)+".weights.h5"
-                predict_filename = self.weight_fn+"_predict_"+str(lastest_num)+".weights.h5"
+                policy_filename = self.weight_fn + "_policy_" + str(lastest_num) + ".weights.h5"
 
-                if policy_filename and predict_filename and os.path.exists(policy_filename) and os.path.exists(predict_filename):
+                if os.path.exists(policy_filename):
                     self.module['learning'].load_weights(self.weight_fn, lastest_num)
-                    print(f'................... Successfully loaded weights from episode {lastest_num}')
-                    print(f'................... Policy file: {policy_filename}')
+                    print(f"................... Successfully loaded weights from episode {lastest_num}")
+                    print(f"................... Policy file: {policy_filename}")
                 else:
-                    print(f'................... Weight files for episode {lastest_num} not found, starting fresh')
+                    print(f"................... Weight file for episode {lastest_num} not found, starting fresh")
             else:
                 if self.weight_num>=0:
-                    policy_filename = self.weight_fn+"_policy_"+str(self.weight_num)+".weights.h5"
-                    predict_filename = self.weight_fn+"_predict_"+str(self.weight_num)+".weights.h5"
+                    policy_filename = self.weight_fn + "_policy_" + str(self.weight_num) + ".weights.h5"
                 else:
-                    policy_filename = self.weight_fn+"_policy.weights.h5"
-                    predict_filename = self.weight_fn+"_predict.weights.h5"
-                # self.module['learning'].load_weights_complete_filename(policy_filename, predict_filename)
-                print(f'................... Non-training mode: Using weight_num={self.weight_num}')
-                print(f'................... Expected policy file: {policy_filename}')
+                    policy_filename = self.weight_fn + "_policy.weights.h5"
+
+                print(f"................... Non-training mode: Using weight_num={self.weight_num}")
+                print(f"................... Expected policy file: {policy_filename}")
+
+                if os.path.exists(policy_filename):
+                    self.module['learning'].load_weights(self.weight_fn, self.weight_num)
+                else:
+                    print("................... Weight file not found, running with random policy")
+
                 self.epsilon = 0.7
                 if self.is_training==0:
                     self.epsilon = 1

--- a/src/CqSim/Reinforcement_learning.py
+++ b/src/CqSim/Reinforcement_learning.py
@@ -43,8 +43,8 @@ class ValueModel(tf.keras.Model):
         
         self.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=self.lr))
         
-        # Build the model by calling it with some dummy data
-        # self.predict(np.random.rand(1, self.input_dim[0], self.input_dim[1]))
+        # Build the model so weights can be loaded immediately
+        self.build((None, self.input_dim[0], self.input_dim[1]))
 
 
         print('start value model ____________')
@@ -57,12 +57,14 @@ class ValueModel(tf.keras.Model):
         return probs
         
     def choose_action(self, state):
-        probabilities = self.predict(state)[0]
+        state = np.asarray(state)
+        probabilities = self(state, training=False).numpy()[0]
         action = np.random.choice(self.action_space, p=probabilities)
         return action
 
     def get_probabilities(self, state):
-        probabilities = self.predict(state)[0]
+        state = np.asarray(state)
+        probabilities = self(state, training=False).numpy()[0]
         return probabilities
 
     def store_transition(self, state, action, reward):
@@ -104,9 +106,13 @@ class ValueModel(tf.keras.Model):
         return loss
 
     def load_weights(self, filename, lastest_num):
+        if not self.built:
+            self.build((None, self.input_dim[0], self.input_dim[1]))
         super().load_weights(filename+"_policy_"+str(lastest_num)+".weights.h5")
 
     def load_weights_complete_filename(self, policy_filename, predict_filename):
+        if not self.built:
+            self.build((None, self.input_dim[0], self.input_dim[1]))
         super().load_weights(policy_filename)
 
     def save_weights(self, filename, next_num):

--- a/train.py
+++ b/train.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Training script replacing train.bash.
+
+This script iterates over jobsets and invokes ``cqsim.py`` for each one.
+It resumes from the last saved weights and periodically runs validation.
+"""
+
+import argparse
+import subprocess
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+SRC_DIR = PROJECT_ROOT / "src"
+CFG_FILE = "config_sys.set"  # relative to SRC_DIR
+JOBSET_DIR = PROJECT_ROOT / "data" / "jobsets"
+RESULT_DIR = PROJECT_ROOT / "data" / "results" / "theta"
+DEBUG_DIR = PROJECT_ROOT / "data" / "debug" / "theta"
+WEIGHT_BASENAME = PROJECT_ROOT / "weights" / "theta" / "dras_theta"
+
+RESULT_DIR.mkdir(parents=True, exist_ok=True)
+DEBUG_DIR.mkdir(parents=True, exist_ok=True)
+WEIGHT_BASENAME.parent.mkdir(parents=True, exist_ok=True)
+
+
+def find_latest_episode() -> int:
+    pattern = re.compile(r"_policy_(\d+)\.weights\.h5$")
+    latest = 0
+    for f in WEIGHT_BASENAME.parent.glob(f"{WEIGHT_BASENAME.name}_policy_*.weights.h5"):
+        m = pattern.search(f.name)
+        if m:
+            latest = max(latest, int(m.group(1)))
+    return latest
+
+
+def average_reward(rew_file: Path):
+    if not rew_file.exists():
+        return None
+    vals = []
+    with rew_file.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                try:
+                    vals.append(float(line))
+                except ValueError:
+                    pass
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def run_cqsim(jobset: Path, episode: int, training: bool) -> Path:
+    basename = jobset.stem
+    job_rel = jobset.relative_to(PROJECT_ROOT)
+    args = [
+        "python", "cqsim.py",
+        "--config_sys", CFG_FILE,
+        "--job", str(job_rel),
+        "--node", str(job_rel),
+        "--weight_num", str(episode),
+        "--is_training", "1" if training else "0",
+        "--output", basename,
+        "--debug", f"debug_{basename}",
+        "--path_in", "../",
+        "--path_fmt", "../",
+        "--path_out", "results/theta/",
+        "--path_debug", "debug/theta/",
+        "--debug_lvl", "10",
+    ]
+    subprocess.run(args, cwd=SRC_DIR, check=True)
+    return RESULT_DIR / f"{basename}.rew"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train rl-scheduler with resume capability")
+    parser.add_argument("--validation_interval", type=int, default=5, help="validate every N episodes")
+    args = parser.parse_args()
+
+    jobsets = (
+        sorted((JOBSET_DIR / "sampled").glob("*.swf")) +
+        sorted((JOBSET_DIR / "real").glob("*.swf")) +
+        sorted((JOBSET_DIR / "synthetic").glob("*.swf"))
+    )
+
+    latest = find_latest_episode()
+    print(f"Latest completed episode: {latest}")
+
+    for idx, jobset in enumerate(jobsets[latest:], start=latest + 1):
+        print(f"=== Episode {idx} ({jobset.stem}) ===")
+        rew = run_cqsim(jobset, idx, training=True)
+        avg = average_reward(rew)
+        if avg is not None:
+            print(f"Episode {idx} average reward: {avg:.4f}")
+        else:
+            print(f"Episode {idx} reward file missing")
+
+        if idx % args.validation_interval == 0:
+            print(f"--- validation after episode {idx} ---")
+            val_job = JOBSET_DIR / "validation_2023_jan.swf"
+            v_rew = run_cqsim(val_job, idx, training=False)
+            v_avg = average_reward(v_rew)
+            if v_avg is not None:
+                print(f"Validation average reward: {v_avg:.4f}")
+            else:
+                print("Validation reward file missing")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `train.py` to replace `train.bash`
- load most recent weights when training restarts
- run periodic validation and print rewards
- fix `Cqsim_sim.py` weight loading logic

## Testing
- `python -m py_compile train.py src/CqSim/Cqsim_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_684fab892e708331b0d6d0afe2df1be1